### PR TITLE
Sheet1/task: parser-implementation

### DIFF
--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -102,7 +102,9 @@ impl Root {
 
                 // Parse integer literals
                 token if token.is_digit(10) => {
-                    expr_stack.push(Expr::Int(token.to_digit(10).unwrap() as i64));
+                    if let Some(int) = token.to_digit(10) {
+                        expr_stack.push(Expr::Int(int as i64));
+                    }
                 }
                 // Parse variable names
                 token if token.is_ascii_lowercase() => expr_stack.push(Expr::Var(token)),

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -99,7 +99,7 @@ impl Root {
             match token {
                 // Ignore whitespace
                 token if token.is_whitespace() => {}
-                
+
                 // Parse integer literals
                 token if token.is_digit(10) => {
                     expr_stack.push(Expr::Int(token.to_digit(10).unwrap() as i64));
@@ -109,6 +109,7 @@ impl Root {
 
                 // Parse operation expressions
                 '+' | '-' | '*' | '/' => {
+                    // first popped is right to assert correct non-commutative operations
                     if let (Some(rhs), Some(lhs)) = (expr_stack.pop(), expr_stack.pop()) {
                         let operation = match token {
                             '+' => Expr::Add(Box::new(lhs), Box::new(rhs)),
@@ -125,8 +126,10 @@ impl Root {
 
                 // Parse variable assignments
                 '=' => {
+                    // first popped is right to assert correct variable assignemnt
                     if let (Some(rhs), Some(Expr::Var(lhs))) = (expr_stack.pop(), expr_stack.pop())
                     {
+                        // an assignemnt is not defined as an expression
                         stmt_list.push(Stmt::Set(lhs, rhs));
                     } else {
                         return Err(Error::Semantic);

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -90,7 +90,6 @@ impl Root {
     ///
     /// [reverse polish notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
     pub fn from_str(str: &str) -> Result<Self, Error> {
-        // TODO: Funktionskörper vervollständigen
         let mut stmt_list: Vec<Stmt> = Vec::new();
         let mut expr_stack: Vec<Expr> = Vec::new();
 

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -118,6 +118,7 @@ impl Root {
                             '-' => Expr::Sub(Box::new(lhs), Box::new(rhs)),
                             '*' => Expr::Mul(Box::new(lhs), Box::new(rhs)),
                             '/' => Expr::Div(Box::new(lhs), Box::new(rhs)),
+							/* Because we don't have a token type for only operations and are not allowed to add one afaik. */
                             _ => unreachable!(), // Shouldn't happen
                         };
                         expr_stack.push(operation)

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -30,7 +30,7 @@
 //!     // other visit methods
 //! }
 //! ```
-//! 
+//!
 //! [reverse polish notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
 
 /// Represents the root of a parse tree.
@@ -39,7 +39,7 @@
 /// of expressions and assignments.
 #[derive(Debug, Default, PartialEq)]
 pub struct Root {
-	pub stmt_list: Vec<Stmt>,
+    pub stmt_list: Vec<Stmt>,
 }
 
 /// Defines the different types of statements that can appear in the parse tree.
@@ -48,8 +48,8 @@ pub struct Root {
 /// variable.
 #[derive(Debug, PartialEq)]
 pub enum Stmt {
-	Expr(Expr),
-	Set(char, Expr),
+    Expr(Expr),
+    Set(char, Expr),
 }
 
 /// Represents all possible expressions that can be parsed and evaluated.
@@ -58,12 +58,12 @@ pub enum Stmt {
 /// (addition, subtraction, multiplication, division).
 #[derive(Debug, PartialEq)]
 pub enum Expr {
-	Int(i64),
-	Var(char),
-	Add(Box<Expr>, Box<Expr>),
-	Sub(Box<Expr>, Box<Expr>),
-	Mul(Box<Expr>, Box<Expr>),
-	Div(Box<Expr>, Box<Expr>),
+    Int(i64),
+    Var(char),
+    Add(Box<Expr>, Box<Expr>),
+    Sub(Box<Expr>, Box<Expr>),
+    Mul(Box<Expr>, Box<Expr>),
+    Div(Box<Expr>, Box<Expr>),
 }
 
 /// Defines error types that can occur during the parsing of expressions.
@@ -72,66 +72,80 @@ pub enum Expr {
 /// on the nature of the error.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
-	/// A lexical error, due to invalid character input.
-	Lexical,
-	/// A syntax error, due to improper arrangement of tokens.
-	Syntax,
-	/// A semantic error, due to assignment to a non-variable expression.
-	Semantic,
+    /// A lexical error, due to invalid character input.
+    Lexical,
+    /// A syntax error, due to improper arrangement of tokens.
+    Syntax,
+    /// A semantic error, due to assignment to a non-variable expression.
+    Semantic,
 }
 
 impl Root {
-	/// Parses a string into a `Root` struct, constructing a list of statements.
-	///
-	/// This method uses a simple stack-based parser to convert strings in
-	/// [reverse polish notation] into statements and expressions.
-	/// 
-	/// Returns an error if the parsing fails due to invalid input.
-	/// 
-	/// [reverse polish notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
-	pub fn from_str(str: &str) -> Result<Self, Error> {
-		// TODO: Funktionskörper vervollständigen
-		let mut stmt_list = Vec::new();
-		let mut expr_stack = Vec::new();
-		
-		for c in str.chars() {
-			match c {
-				c if c.is_whitespace() => {}
-				c if c.is_digit(10) => {
-					todo!("Ziffer in Zahl konvertieren und auf den Stapel legen")
-				}
-				c if c.is_ascii_lowercase() => {
-					todo!("Variablenname auf den Stapel legen")
-				}
-				'+' => {
-					todo!("Additionsknoten auf den Stapel legen")
-				}
-				'-' => {
-					todo!("Subtraktionsknoten auf den Stapel legen")
-				}
-				'*' => {
-					todo!("Multiplikationsknoten auf den Stapel legen")
-				}
-				'/' => {
-					todo!("Divisionsknoten auf den Stapel legen")
-				}
-				'=' => {
-					todo!("Zuweisungsknoten auf den Stapel legen");
-				}
-				_ => todo!("geeigneten Fehlercode zurückgeben"),
-			}
-		}
-		
-		if let Some(expr) = expr_stack.pop() {
-			stmt_list.push(Stmt::Expr(expr));
-		}
-		
-		if !expr_stack.is_empty() {
-			todo!("geeigneten Fehlercode zurückgeben")
-		} else {
-			Ok(Root { stmt_list })
-		}
-	}
+    /// Parses a string into a `Root` struct, constructing a list of statements.
+    ///
+    /// This method uses a simple stack-based parser to convert strings in
+    /// [reverse polish notation] into statements and expressions.
+    ///
+    /// Returns an error if the parsing fails due to invalid input.
+    ///
+    /// [reverse polish notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
+    pub fn from_str(str: &str) -> Result<Self, Error> {
+        // TODO: Funktionskörper vervollständigen
+        let mut stmt_list: Vec<Stmt> = Vec::new();
+        let mut expr_stack: Vec<Expr> = Vec::new();
+
+        for c in str.chars() {
+            match c {
+                c if c.is_whitespace() => {}
+                c if c.is_digit(10) => {
+                    expr_stack.push(Expr::Int(c.to_digit(10).unwrap().into()));
+                }
+                c if c.is_ascii_lowercase() => expr_stack.push(Expr::Var(c)),
+                '+' => {
+                    let right = Box::new(expr_stack.pop().unwrap());
+                    let left = Box::new(expr_stack.pop().unwrap());
+                    expr_stack.push(Expr::Add(left, right))
+                }
+                '-' => {
+                    let right = Box::new(expr_stack.pop().unwrap());
+                    let left = Box::new(expr_stack.pop().unwrap());
+                    expr_stack.push(Expr::Sub(left, right))
+                }
+                '*' => {
+                    let right = Box::new(expr_stack.pop().unwrap());
+                    let left = Box::new(expr_stack.pop().unwrap());
+                    expr_stack.push(Expr::Mul(left, right))
+                }
+                '/' => {
+                    let right = Box::new(expr_stack.pop().unwrap());
+                    let left = Box::new(expr_stack.pop().unwrap());
+                    expr_stack.push(Expr::Div(left, right))
+                }
+                '=' => {
+                    if let Some(right) = expr_stack.pop() {
+                        if let Some(Expr::Var(left)) = expr_stack.pop() {
+                            stmt_list.push(Stmt::Set(left, right));
+                        } else {
+                            return Err(Error::Semantic);
+                        }
+                    } else {
+                        return Err(Error::Syntax);
+                    }
+                }
+                _ => return Err(Error::Lexical),
+            }
+        }
+
+        if let Some(expr) = expr_stack.pop() {
+            stmt_list.push(Stmt::Expr(expr));
+        }
+
+        if !expr_stack.is_empty() {
+            return Err(Error::Syntax);
+        } else {
+            Ok(Root { stmt_list })
+        }
+    }
 }
 
 /// Provides a visitor for traversing the parse tree.
@@ -139,171 +153,163 @@ impl Root {
 /// This trait should be implemented by any type that needs to perform
 /// operations on the parse tree.
 pub trait Visitor {
-	fn visit_root(&mut self, r: &Root) {
-		for item in r.stmt_list.iter() {
-			self.visit_stmt(item);
-		}
-	}
-	
-	fn visit_stmt(&mut self, s: &Stmt) {
-		match s {
-			Stmt::Expr(e) => self.visit_expr(e),
-			Stmt::Set(_, e) => self.visit_expr(e),
-		}
-	}
-	
-	fn visit_expr(&mut self, e: &Expr) {
-		match e {
-			Expr::Int(_) | Expr::Var(_) => {}
-			Expr::Add(lhs, rhs) => {
-				self.visit_expr(lhs);
-				self.visit_expr(rhs);
-			}
-			Expr::Sub(lhs, rhs) => {
-				self.visit_expr(lhs);
-				self.visit_expr(rhs);
-			}
-			Expr::Mul(lhs, rhs) => {
-				self.visit_expr(lhs);
-				self.visit_expr(rhs);
-			}
-			Expr::Div(lhs, rhs) => {
-				self.visit_expr(lhs);
-				self.visit_expr(rhs);
-			}
-		}
-	}
+    fn visit_root(&mut self, r: &Root) {
+        for item in r.stmt_list.iter() {
+            self.visit_stmt(item);
+        }
+    }
+
+    fn visit_stmt(&mut self, s: &Stmt) {
+        match s {
+            Stmt::Expr(e) => self.visit_expr(e),
+            Stmt::Set(_, e) => self.visit_expr(e),
+        }
+    }
+
+    fn visit_expr(&mut self, e: &Expr) {
+        match e {
+            Expr::Int(_) | Expr::Var(_) => {}
+            Expr::Add(lhs, rhs) => {
+                self.visit_expr(lhs);
+                self.visit_expr(rhs);
+            }
+            Expr::Sub(lhs, rhs) => {
+                self.visit_expr(lhs);
+                self.visit_expr(rhs);
+            }
+            Expr::Mul(lhs, rhs) => {
+                self.visit_expr(lhs);
+                self.visit_expr(rhs);
+            }
+            Expr::Div(lhs, rhs) => {
+                self.visit_expr(lhs);
+                self.visit_expr(rhs);
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for Error {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::Lexical => write!(f, "Lexical error: unexpected character"),
-			Self::Syntax => write!(f, "Syntax error: wrong number of operands"),
-			Self::Semantic => write!(f, "Semantic error: assignment to non-variable"),
-		}
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lexical => write!(f, "Lexical error: unexpected character"),
+            Self::Syntax => write!(f, "Syntax error: wrong number of operands"),
+            Self::Semantic => write!(f, "Semantic error: assignment to non-variable"),
+        }
+    }
 }
 
 // unit-tests
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	
-	impl Root {
-		/// Creates a parse tree from a single [`Stmt`].
-		/// 
-		/// This method only exists during testing.
-		pub fn from_stmt(s: Stmt) -> Self {
-			Self { stmt_list: vec![s] }
-		}
-	}
-	
-	impl Stmt {
-		/// Creates an expression `Stmt` for adding two numbers.
-		///
-		/// This method only exists during testing.
-		pub fn add(lhs: i64, rhs: i64) -> Self {
-			Stmt::Expr(
-				Expr::Add(
-					Box::new(Expr::Int(lhs)),
-					Box::new(Expr::Int(rhs)),
-				)
-			)
-		}
-		
-		/// Creates an expression `Stmt` for subtracting two numbers.
-		///
-		/// This method only exists during testing.
-		pub fn sub(lhs: i64, rhs: i64) -> Self {
-			Stmt::Expr(
-				Expr::Sub(
-					Box::new(Expr::Int(lhs)),
-					Box::new(Expr::Int(rhs)),
-				)
-			)
-		}
-		
-		/// Creates an expression `Stmt` for multiplying two numbers.
-		/// 
-		/// This method only exists during testing.
-		pub fn mul(lhs: i64, rhs: i64) -> Self {
-			Stmt::Expr(
-				Expr::Mul(
-					Box::new(Expr::Int(lhs)),
-					Box::new(Expr::Int(rhs)),
-				)
-			)
-		}
-		
-		/// Creates an expression `Stmt` for dividing two numbers.
-		/// 
-		/// This method only exists during testing.
-		pub fn div(lhs: i64, rhs: i64) -> Self {
-			Stmt::Expr(
-				Expr::Div(
-					Box::new(Expr::Int(lhs)),
-					Box::new(Expr::Int(rhs)),
-				)
-			)
-		}
-		
-		/// Creates a `Stmt` for assigning a number to a variable.
-		/// 
-		/// This method only exists during testing.
-		pub fn set(lhs: char, rhs: i64) -> Self {
-			Stmt::Set(lhs, Expr::Int(rhs))
-		}
-	}
-	
-	#[test]
-	fn parse_add() {
-		let tree = Root::from_str("4 2 +");
-		assert_eq!(tree, Ok(Root::from_stmt(Stmt::add(4, 2))));
-	}
-	
-	#[test]
-	fn parse_sub() {
-		let tree = Root::from_str("4 2 -");
-		assert_eq!(tree, Ok(Root::from_stmt(Stmt::sub(4, 2))));
-	}
-	
-	#[test]
-	fn parse_mul() {
-		let tree = Root::from_str("4 2 *");
-		assert_eq!(tree, Ok(Root::from_stmt(Stmt::mul(4, 2))));
-	}
-	
-	#[test]
-	fn parse_div() {
-		let tree = Root::from_str("4 2 /");
-		assert_eq!(tree, Ok(Root::from_stmt(Stmt::div(4, 2))));
-	}
-	
-	#[test]
-	fn parse_set() {
-		let tree = Root::from_str("a 1 =");
-		assert_eq!(tree, Ok(Root::from_stmt(Stmt::set('a', 1))));
-	}
-	
-	#[test]
-	fn parse_error1() {
-		assert!(Root::from_str("1 2 ^").is_err());
-	}
-	
-	#[test]
-	fn parse_error2() {
-		assert!(Root::from_str("1 2 3 + ").is_err());
-	}
-	
-	#[test]
-	fn parse_error3() {
-		assert!(Root::from_str("1 2 + *").is_err());
-	}
-	
-	#[test]
-	fn parse_error4() {
-		assert!(Root::from_str("1 1 =").is_err());
-	}
+    use super::*;
+
+    impl Root {
+        /// Creates a parse tree from a single [`Stmt`].
+        ///
+        /// This method only exists during testing.
+        pub fn from_stmt(s: Stmt) -> Self {
+            Self { stmt_list: vec![s] }
+        }
+    }
+
+    impl Stmt {
+        /// Creates an expression `Stmt` for adding two numbers.
+        ///
+        /// This method only exists during testing.
+        pub fn add(lhs: i64, rhs: i64) -> Self {
+            Stmt::Expr(Expr::Add(
+                Box::new(Expr::Int(lhs)),
+                Box::new(Expr::Int(rhs)),
+            ))
+        }
+
+        /// Creates an expression `Stmt` for subtracting two numbers.
+        ///
+        /// This method only exists during testing.
+        pub fn sub(lhs: i64, rhs: i64) -> Self {
+            Stmt::Expr(Expr::Sub(
+                Box::new(Expr::Int(lhs)),
+                Box::new(Expr::Int(rhs)),
+            ))
+        }
+
+        /// Creates an expression `Stmt` for multiplying two numbers.
+        ///
+        /// This method only exists during testing.
+        pub fn mul(lhs: i64, rhs: i64) -> Self {
+            Stmt::Expr(Expr::Mul(
+                Box::new(Expr::Int(lhs)),
+                Box::new(Expr::Int(rhs)),
+            ))
+        }
+
+        /// Creates an expression `Stmt` for dividing two numbers.
+        ///
+        /// This method only exists during testing.
+        pub fn div(lhs: i64, rhs: i64) -> Self {
+            Stmt::Expr(Expr::Div(
+                Box::new(Expr::Int(lhs)),
+                Box::new(Expr::Int(rhs)),
+            ))
+        }
+
+        /// Creates a `Stmt` for assigning a number to a variable.
+        ///
+        /// This method only exists during testing.
+        pub fn set(lhs: char, rhs: i64) -> Self {
+            Stmt::Set(lhs, Expr::Int(rhs))
+        }
+    }
+
+    #[test]
+    fn parse_add() {
+        let tree = Root::from_str("4 2 +");
+        assert_eq!(tree, Ok(Root::from_stmt(Stmt::add(4, 2))));
+    }
+
+    #[test]
+    fn parse_sub() {
+        let tree = Root::from_str("4 2 -");
+        assert_eq!(tree, Ok(Root::from_stmt(Stmt::sub(4, 2))));
+    }
+
+    #[test]
+    fn parse_mul() {
+        let tree = Root::from_str("4 2 *");
+        assert_eq!(tree, Ok(Root::from_stmt(Stmt::mul(4, 2))));
+    }
+
+    #[test]
+    fn parse_div() {
+        let tree = Root::from_str("4 2 /");
+        assert_eq!(tree, Ok(Root::from_stmt(Stmt::div(4, 2))));
+    }
+
+    #[test]
+    fn parse_set() {
+        let tree = Root::from_str("a 1 =");
+        assert_eq!(tree, Ok(Root::from_stmt(Stmt::set('a', 1))));
+    }
+
+    #[test]
+    fn parse_error1() {
+        assert!(Root::from_str("1 2 ^").is_err());
+    }
+
+    #[test]
+    fn parse_error2() {
+        assert!(Root::from_str("1 2 3 + ").is_err());
+    }
+
+    #[test]
+    fn parse_error3() {
+        assert!(Root::from_str("1 2 + *").is_err());
+    }
+
+    #[test]
+    fn parse_error4() {
+        assert!(Root::from_str("1 1 =").is_err());
+    }
 }

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -155,7 +155,8 @@ impl Root {
     }
 }
 
-/// Provides a visitor for traversing the parse tree.
+/// Provides a visitor for traversing the parse tree following the Depth-first search
+/// algorithm.
 ///
 /// This trait should be implemented by any type that needs to perform
 /// operations on the parse tree.


### PR DESCRIPTION
<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; font-size: 15px; text-align: left;">Die Funktion zum Parsen finden Sie in der Quelldatei<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 13.125px; color: black; overflow-wrap: break-word;">parse_tree.rs</code>. Der Parser soll Ausdrücke in<span class="Apple-converted-space"> </span><a href="https://de.wikipedia.org/wiki/Umgekehrte_polnische_Notation" style="box-sizing: border-box; color: rgb(0, 55, 108); text-decoration: none; background-color: transparent;">umgekehrter polnischer Notation</a><span class="Apple-converted-space"> </span>akzeptieren und daraus einen Parsebaum konstruieren, der den eingelesenen Ausdruck repräsentiert. Ggf. auftretende Fehler sollen erkannt und in Form einer der drei möglichen Fehlerarten<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 13.125px; color: black; overflow-wrap: break-word;"><span style="box-sizing: border-box; color: rgb(143, 89, 2);">Error</span>::<span style="box-sizing: border-box; color: rgb(204, 0, 0); font-style: italic;">Lexical</span></code>,<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 13.125px; color: black; overflow-wrap: break-word;"><span style="box-sizing: border-box; color: rgb(143, 89, 2);">Error</span>::<span style="box-sizing: border-box; color: rgb(204, 0, 0); font-style: italic;">Syntax</span></code><span class="Apple-converted-space"> </span>oder<span class="Apple-converted-space"> </span><code style="box-sizing: border-box; font-family: SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 13.125px; color: black; overflow-wrap: break-word;"><span style="box-sizing: border-box; color: rgb(143, 89, 2);">Error</span>::<span style="box-sizing: border-box; color: rgb(204, 0, 0); font-style: italic;">Semantic</span></code><span class="Apple-converted-space"> </span>zurückgegeben werden.</p><h4 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 0.5rem; font-weight: 400; line-height: 1.1; font-size: 1.40625rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; text-align: left;">Beispielausdrücke</h4><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; font-size: 15px; text-align: left;">Wie oben erwähnt, soll der Parser Ausdrücke in umgekehrter polnischer Notation akzeptieren.</p>
Beispielausdruck | infix Notation
-- | --
1 2 + | 1 + 2
1 2 3 + * | 1 * (2 + 3)
a 1 = | a = 1
a 1 = a a + | a = 1; a + a

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; font-size: 15px; text-align: left;"><br style="box-sizing: border-box;"></p><p id="yui_3_17_2_1_1713925924733_109" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; font-size: 15px; text-align: left;">Welche Fehlerart diagnostiziert wird, hängt konzeptionell von der Übersetzungsphase ab, in der der entsprechende Fehler detektiert wird. Da in diesem einfachen Beispiel Scanner, Parser und Typprüfung zusammenfallen, wählen wir hier die Konvention, dass<span class="Apple-converted-space"> </span><em style="box-sizing: border-box;">lexikalische</em><span class="Apple-converted-space"> </span>Fehler durch unbekannte Zeichen im Eingabestrom hervorgerufen werden,<span class="Apple-converted-space"> </span><em style="box-sizing: border-box;">syntaktische</em><span class="Apple-converted-space"> </span>Fehler durch die falsche Anzahl an Operanden bzw. Operatoren entstehen und<span class="Apple-converted-space"> </span><em style="box-sizing: border-box;">semantische</em><span class="Apple-converted-space"> </span>Fehler die Folge von Zuweisungen in nicht-zuweisungsfähige Strukturen sind.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; caret-color: rgb(29, 33, 37); color: rgb(29, 33, 37); font-family: &quot;Source Sans 3&quot;, sans-serif; font-size: 15px; text-align: left;">Diese Konvention erscheint willkürlich, wird aber in den folgenden Aufgabenblättern verständlich.</p>Die Funktion zum Parsen finden Sie in der Quelldatei parse_tree.rs. Der Parser soll Ausdrücke in [umgekehrter polnischer Notation](https://de.wikipedia.org/wiki/Umgekehrte_polnische_Notation) akzeptieren und daraus einen Parsebaum konstruieren, der den eingelesenen Ausdruck repräsentiert. Ggf. auftretende Fehler sollen erkannt und in Form einer der drei möglichen Fehlerarten Error::Lexical, Error::Syntax oder Error::Semantic zurückgegeben werden.

Beispielausdrücke
Wie oben erwähnt, soll der Parser Ausdrücke in umgekehrter polnischer Notation akzeptieren.

Beispielausdruck   	infix Notation
1 2 +	1 + 2
1 2 3 + *	1 * (2 + 3)
a 1 =	a = 1
a 1 = a a +	a = 1; a + a

Folgende Ausdrücke sollen einen Fehler produzieren:

Beispielausdruck   	gemeldete Fehlerart
1 2 ^	lexikalisch
1 2 3 +	syntaktisch
1 2 + *	syntaktisch
1 1 =	semantisch


Welche Fehlerart diagnostiziert wird, hängt konzeptionell von der Übersetzungsphase ab, in der der entsprechende Fehler detektiert wird. Da in diesem einfachen Beispiel Scanner, Parser und Typprüfung zusammenfallen, wählen wir hier die Konvention, dass lexikalische Fehler durch unbekannte Zeichen im Eingabestrom hervorgerufen werden, syntaktische Fehler durch die falsche Anzahl an Operanden bzw. Operatoren entstehen und semantische Fehler die Folge von Zuweisungen in nicht-zuweisungsfähige Strukturen sind.

Diese Konvention erscheint willkürlich, wird aber in den folgenden Aufgabenblättern verständlich.